### PR TITLE
Refactor to Eliminate Repetitive Mock Object Creation in  `ServletPipelineRequestDispatcherTest`

### DIFF
--- a/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
@@ -66,8 +66,6 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
             new HashMap<String, String>(),
             null);
 
-    final Injector injector = mock(Injector.class);
-    final Binding<HttpServlet> binding = mock(Binding.class);
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
 
     when(requestMock.getAttribute(A_KEY)).thenReturn(A_VALUE);
@@ -86,18 +84,8 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
           }
         };
 
-    when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
-    when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
-    when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);
-
-    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
-
-    Binding<ServletDefinition> mockBinding = mock(Binding.class);
-    when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
-        .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
-    Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
-    when(mockBinding.getProvider()).thenReturn(bindingProvider);
-
+    final Injector injector = creatMockInjector(servletDefinition, mockServlet);
+    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
@@ -122,8 +110,6 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
             new HashMap<String, String>(),
             null);
 
-    final Injector injector = mock(Injector.class);
-    final Binding<HttpServlet> binding = mock(Binding.class);
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 
@@ -145,19 +131,8 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
           }
         };
 
-    when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
-    when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
-
-    when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);
-
-    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
-
-    Binding<ServletDefinition> mockBinding = mock(Binding.class);
-    when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
-        .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
-    Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
-    when(mockBinding.getProvider()).thenReturn(bindingProvider);
-
+    final Injector injector = creatMockInjector(servletDefinition, mockServlet);
+    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
@@ -196,8 +171,6 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
             new HashMap<String, String>(),
             null);
 
-    final Injector injector = mock(Injector.class);
-    final Binding<HttpServlet> binding = mock(Binding.class);
     final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 
@@ -215,19 +188,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
           }
         };
 
-    when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
-    when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
-
-    when(injector.getInstance(Key.get(HttpServlet.class))).thenReturn(mockServlet);
-
-    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
-
-    Binding<ServletDefinition> mockBinding = mock(Binding.class);
-    when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
-        .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
-    Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
-    when(mockBinding.getProvider()).thenReturn(bindingProvider);
-
+    final Injector injector = creatMockInjector(servletDefinition, mockServlet);
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
@@ -240,10 +201,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testWrappedRequestUriAndUrlConsistency() {
-    final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    when(mockRequest.getScheme()).thenReturn("http");
-    when(mockRequest.getServerName()).thenReturn("the.server");
-    when(mockRequest.getServerPort()).thenReturn(12345);
+    final HttpServletRequest mockRequest = createMockRequest("http",12345);
 
     HttpServletRequest wrappedRequest = ManagedServletPipeline.wrapRequest(mockRequest, "/new-uri");
     assertEquals("/new-uri", wrappedRequest.getRequestURI());
@@ -251,10 +209,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testWrappedRequestUrlNegativePort() {
-    final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    when(mockRequest.getScheme()).thenReturn("http");
-    when(mockRequest.getServerName()).thenReturn("the.server");
-    when(mockRequest.getServerPort()).thenReturn(-1);
+    final HttpServletRequest mockRequest = createMockRequest("http",-1);
 
     HttpServletRequest wrappedRequest = ManagedServletPipeline.wrapRequest(mockRequest, "/new-uri");
     assertEquals("/new-uri", wrappedRequest.getRequestURI());
@@ -262,10 +217,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testWrappedRequestUrlDefaultPort() {
-    final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    when(mockRequest.getScheme()).thenReturn("http");
-    when(mockRequest.getServerName()).thenReturn("the.server");
-    when(mockRequest.getServerPort()).thenReturn(80);
+    final HttpServletRequest mockRequest = createMockRequest("http",80);
 
     HttpServletRequest wrappedRequest = ManagedServletPipeline.wrapRequest(mockRequest, "/new-uri");
     assertEquals("/new-uri", wrappedRequest.getRequestURI());
@@ -273,13 +225,34 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testWrappedRequestUrlDefaultHttpsPort() {
-    final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    when(mockRequest.getScheme()).thenReturn("https");
-    when(mockRequest.getServerName()).thenReturn("the.server");
-    when(mockRequest.getServerPort()).thenReturn(443);
+    final HttpServletRequest mockRequest = createMockRequest("https",443);
 
     HttpServletRequest wrappedRequest = ManagedServletPipeline.wrapRequest(mockRequest, "/new-uri");
     assertEquals("/new-uri", wrappedRequest.getRequestURI());
     assertEquals("https://the.server/new-uri", wrappedRequest.getRequestURL().toString());
+  }
+  public final HttpServletRequest createMockRequest(String http, int serverPort){
+    HttpServletRequest mockRequest=mock(HttpServletRequest.class);
+    when(mockRequest.getScheme()).thenReturn(http);
+    when(mockRequest.getServerName()).thenReturn("the.server");
+    when(mockRequest.getServerPort()).thenReturn(serverPort);
+    return  mockRequest;
+  }
+  public final Injector creatMockInjector (ServletDefinition servletDefinition,HttpServlet mockServlet){
+    final Binding<HttpServlet> binding = mock(Binding.class);
+    when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
+
+    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
+    Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
+
+    Binding<ServletDefinition> mockBinding = mock(Binding.class);
+    when(mockBinding.getProvider()).thenReturn(bindingProvider);
+
+    final Injector injector = mock(Injector.class);
+    when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
+    when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);
+    when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
+            .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
+    return injector;
   }
 }

--- a/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
@@ -55,16 +55,16 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   private static final Key<HttpServlet> HTTP_SERLVET_KEY = Key.get(HttpServlet.class);
   private static final String A_KEY = "thinglyDEgintly" + new Date() + UUID.randomUUID();
   private static final String A_VALUE =
-          ServletPipelineRequestDispatcherTest.class.toString() + new Date() + UUID.randomUUID();
+      ServletPipelineRequestDispatcherTest.class.toString() + new Date() + UUID.randomUUID();
 
   public final void testIncludeManagedServlet() throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-            new ServletDefinition(
-                    Key.get(HttpServlet.class),
-                    UriPatternType.get(UriPatternType.SERVLET, pattern),
-                    new HashMap<String, String>(),
-                    null);
+        new ServletDefinition(
+            Key.get(HttpServlet.class),
+            UriPatternType.get(UriPatternType.SERVLET, pattern),
+            new HashMap<String, String>(),
+            null);
 
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
 
@@ -72,25 +72,25 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
 
     final boolean[] run = new boolean[1];
     final HttpServlet mockServlet =
-            new HttpServlet() {
-              @Override
-              protected void service(
-                      HttpServletRequest request, HttpServletResponse httpServletResponse)
-                      throws ServletException, IOException {
-                run[0] = true;
+        new HttpServlet() {
+          @Override
+          protected void service(
+              HttpServletRequest request, HttpServletResponse httpServletResponse)
+              throws ServletException, IOException {
+            run[0] = true;
 
-                final Object o = request.getAttribute(A_KEY);
-                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-              }
-            };
+            final Object o = request.getAttribute(A_KEY);
+            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+          }
+        };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-
+    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
     dispatcher.include(requestMock, mock(HttpServletResponse.class));
@@ -104,11 +104,11 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   public final void testForwardToManagedServlet() throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-            new ServletDefinition(
-                    Key.get(HttpServlet.class),
-                    UriPatternType.get(UriPatternType.SERVLET, pattern),
-                    new HashMap<String, String>(),
-                    null);
+        new ServletDefinition(
+            Key.get(HttpServlet.class),
+            UriPatternType.get(UriPatternType.SERVLET, pattern),
+            new HashMap<String, String>(),
+            null);
 
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -119,25 +119,25 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
 
     final List<String> paths = new ArrayList<>();
     final HttpServlet mockServlet =
-            new HttpServlet() {
-              @Override
-              protected void service(
-                      HttpServletRequest request, HttpServletResponse httpServletResponse)
-                      throws ServletException, IOException {
-                paths.add(request.getRequestURI());
+        new HttpServlet() {
+          @Override
+          protected void service(
+              HttpServletRequest request, HttpServletResponse httpServletResponse)
+              throws ServletException, IOException {
+            paths.add(request.getRequestURI());
 
-                final Object o = request.getAttribute(A_KEY);
-                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-              }
-            };
+            final Object o = request.getAttribute(A_KEY);
+            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+          }
+        };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-
+    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
     dispatcher.forward(requestMock, mockResponse);
@@ -150,7 +150,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testForwardToManagedServletFailureOnCommittedBuffer()
-          throws IOException, ServletException {
+      throws IOException, ServletException {
     IllegalStateException expected = null;
     try {
       forwardToManagedServletFailureOnCommittedBuffer();
@@ -162,14 +162,14 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void forwardToManagedServletFailureOnCommittedBuffer()
-          throws IOException, ServletException {
+      throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-            new ServletDefinition(
-                    Key.get(HttpServlet.class),
-                    UriPatternType.get(UriPatternType.SERVLET, pattern),
-                    new HashMap<String, String>(),
-                    null);
+        new ServletDefinition(
+            Key.get(HttpServlet.class),
+            UriPatternType.get(UriPatternType.SERVLET, pattern),
+            new HashMap<String, String>(),
+            null);
 
     final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -177,23 +177,23 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
     when(mockResponse.isCommitted()).thenReturn(true);
 
     final HttpServlet mockServlet =
-            new HttpServlet() {
-              @Override
-              protected void service(
-                      HttpServletRequest request, HttpServletResponse httpServletResponse)
-                      throws ServletException, IOException {
+        new HttpServlet() {
+          @Override
+          protected void service(
+              HttpServletRequest request, HttpServletResponse httpServletResponse)
+              throws ServletException, IOException {
 
-                final Object o = request.getAttribute(A_KEY);
-                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-              }
-            };
+            final Object o = request.getAttribute(A_KEY);
+            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+          }
+        };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
 

--- a/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
@@ -55,16 +55,16 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   private static final Key<HttpServlet> HTTP_SERLVET_KEY = Key.get(HttpServlet.class);
   private static final String A_KEY = "thinglyDEgintly" + new Date() + UUID.randomUUID();
   private static final String A_VALUE =
-      ServletPipelineRequestDispatcherTest.class.toString() + new Date() + UUID.randomUUID();
+          ServletPipelineRequestDispatcherTest.class.toString() + new Date() + UUID.randomUUID();
 
   public final void testIncludeManagedServlet() throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-        new ServletDefinition(
-            Key.get(HttpServlet.class),
-            UriPatternType.get(UriPatternType.SERVLET, pattern),
-            new HashMap<String, String>(),
-            null);
+            new ServletDefinition(
+                    Key.get(HttpServlet.class),
+                    UriPatternType.get(UriPatternType.SERVLET, pattern),
+                    new HashMap<String, String>(),
+                    null);
 
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
 
@@ -72,25 +72,25 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
 
     final boolean[] run = new boolean[1];
     final HttpServlet mockServlet =
-        new HttpServlet() {
-          @Override
-          protected void service(
-              HttpServletRequest request, HttpServletResponse httpServletResponse)
-              throws ServletException, IOException {
-            run[0] = true;
+            new HttpServlet() {
+              @Override
+              protected void service(
+                      HttpServletRequest request, HttpServletResponse httpServletResponse)
+                      throws ServletException, IOException {
+                run[0] = true;
 
-            final Object o = request.getAttribute(A_KEY);
-            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-          }
-        };
+                final Object o = request.getAttribute(A_KEY);
+                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+              }
+            };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-    
+
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
     dispatcher.include(requestMock, mock(HttpServletResponse.class));
@@ -104,11 +104,11 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   public final void testForwardToManagedServlet() throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-        new ServletDefinition(
-            Key.get(HttpServlet.class),
-            UriPatternType.get(UriPatternType.SERVLET, pattern),
-            new HashMap<String, String>(),
-            null);
+            new ServletDefinition(
+                    Key.get(HttpServlet.class),
+                    UriPatternType.get(UriPatternType.SERVLET, pattern),
+                    new HashMap<String, String>(),
+                    null);
 
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -119,25 +119,25 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
 
     final List<String> paths = new ArrayList<>();
     final HttpServlet mockServlet =
-        new HttpServlet() {
-          @Override
-          protected void service(
-              HttpServletRequest request, HttpServletResponse httpServletResponse)
-              throws ServletException, IOException {
-            paths.add(request.getRequestURI());
+            new HttpServlet() {
+              @Override
+              protected void service(
+                      HttpServletRequest request, HttpServletResponse httpServletResponse)
+                      throws ServletException, IOException {
+                paths.add(request.getRequestURI());
 
-            final Object o = request.getAttribute(A_KEY);
-            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-          }
-        };
+                final Object o = request.getAttribute(A_KEY);
+                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+              }
+            };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-    
+
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
     dispatcher.forward(requestMock, mockResponse);
@@ -150,7 +150,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void testForwardToManagedServletFailureOnCommittedBuffer()
-      throws IOException, ServletException {
+          throws IOException, ServletException {
     IllegalStateException expected = null;
     try {
       forwardToManagedServletFailureOnCommittedBuffer();
@@ -162,14 +162,14 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
   }
 
   public final void forwardToManagedServletFailureOnCommittedBuffer()
-      throws IOException, ServletException {
+          throws IOException, ServletException {
     String pattern = "blah.html";
     final ServletDefinition servletDefinition =
-        new ServletDefinition(
-            Key.get(HttpServlet.class),
-            UriPatternType.get(UriPatternType.SERVLET, pattern),
-            new HashMap<String, String>(),
-            null);
+            new ServletDefinition(
+                    Key.get(HttpServlet.class),
+                    UriPatternType.get(UriPatternType.SERVLET, pattern),
+                    new HashMap<String, String>(),
+                    null);
 
     final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -177,23 +177,23 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
     when(mockResponse.isCommitted()).thenReturn(true);
 
     final HttpServlet mockServlet =
-        new HttpServlet() {
-          @Override
-          protected void service(
-              HttpServletRequest request, HttpServletResponse httpServletResponse)
-              throws ServletException, IOException {
+            new HttpServlet() {
+              @Override
+              protected void service(
+                      HttpServletRequest request, HttpServletResponse httpServletResponse)
+                      throws ServletException, IOException {
 
-            final Object o = request.getAttribute(A_KEY);
-            assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
-          }
-        };
+                final Object o = request.getAttribute(A_KEY);
+                assertEquals("Wrong attrib returned - " + o, A_VALUE, o);
+              }
+            };
 
     final Injector injector = creatMockInjector(servletDefinition, mockServlet);
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
     final RequestDispatcher dispatcher =
-        new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
+            new ManagedServletPipeline(injector).getRequestDispatcher(pattern);
 
     assertNotNull(dispatcher);
 
@@ -238,21 +238,28 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
     when(mockRequest.getServerPort()).thenReturn(serverPort);
     return  mockRequest;
   }
-  public final Injector creatMockInjector (ServletDefinition servletDefinition,HttpServlet mockServlet){
+  public final Binding<HttpServlet> creatMockBinding(){
     final Binding<HttpServlet> binding = mock(Binding.class);
     when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
-
-    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
+    return binding;
+  }
+  public final Binding<ServletDefinition> creatMockBinding(ServletDefinition servletDefinition){
     Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
 
     Binding<ServletDefinition> mockBinding = mock(Binding.class);
     when(mockBinding.getProvider()).thenReturn(bindingProvider);
-
+    return mockBinding;
+  }
+  public final Injector creatMockInjector (Binding<HttpServlet> binding, HttpServlet mockServlet, Binding<ServletDefinition> mockBinding){
+    final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
     final Injector injector = mock(Injector.class);
     when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
     when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);
     when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
             .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
     return injector;
+  }
+  public final Injector creatMockInjector (ServletDefinition servletDefinition,HttpServlet mockServlet){
+    return creatMockInjector(creatMockBinding(), mockServlet, creatMockBinding(servletDefinition));
   }
 }

--- a/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletPipelineRequestDispatcherTest.java
@@ -67,7 +67,6 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
             null);
 
     final HttpServletRequest requestMock = mock(HttpServletRequest.class);
-
     when(requestMock.getAttribute(A_KEY)).thenReturn(A_VALUE);
 
     final boolean[] run = new boolean[1];
@@ -84,8 +83,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
           }
         };
 
-    final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-    
+    final Injector injector = creatMockInjector(servletDefinition, mockServlet);    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 
@@ -131,8 +129,7 @@ public class ServletPipelineRequestDispatcherTest extends TestCase {
           }
         };
 
-    final Injector injector = creatMockInjector(servletDefinition, mockServlet);
-    
+    final Injector injector = creatMockInjector(servletDefinition, mockServlet);    
     // Have to init the Servlet before we can dispatch to it.
     servletDefinition.init(null, injector, Sets.<HttpServlet>newIdentityHashSet());
 


### PR DESCRIPTION
Hi there!

While working with the `ServletPipelineRequestDispatcherTest`, I've noticed that there are four mock variables repeatedly created across various tests. To simplify the code, I propose a small refactor to eliminate these redundancies, which could reduce the code by 60 lines.

Here's a summary of the repetitive mock creations:
- **`Binding<HttpServlet>`**: Repeated mocked 3 times
- **`Binding<ServletDefinition>`**: Repeated mocked 3 times
- **`Injector`**: Repeated mocked 3 times
- **`HttpServletRequest`**: Repeated mocked 4 times

For instance, creating a mock for `HttpServletRequest` currently looks like this:

```java
final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
when(mockRequest.getScheme()).thenReturn("https");
when(mockRequest.getServerName()).thenReturn("the.server");
when(mockRequest.getServerPort()).thenReturn(443);
```

To make this process more efficient, we can introduce a `createMockRequest` method:

```java
public final HttpServletRequest createMockRequest(String scheme, int serverPort) {
    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
    when(mockRequest.getScheme()).thenReturn(scheme);
    when(mockRequest.getServerName()).thenReturn("the.server");
    when(mockRequest.getServerPort()).thenReturn(serverPort);
    return mockRequest;
}
```

With this method, creating a mock `HttpServletRequest` becomes:

```java
final HttpServletRequest mockRequest = createMockRequest("https", 443);
```

Similarly, for the mock creation of `Binding<HttpServlet>`, `Binding<ServletDefinition>` and `Injector` We can introduce methods for creating mocks for these classes as well:

**mock `Binding<HttpServlet>` creation**：
```java
public final Binding<HttpServlet> createMockBinding() {
    final Binding<HttpServlet> binding = mock(Binding.class);
    when(binding.acceptScopingVisitor(any())).thenReturn(true);
    return binding;
}
```
**mock `Binding<ServletDefinition>` creation**：
```java
public final Binding<ServletDefinition> createMockBinding(ServletDefinition servletDefinition) {
    Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
    Binding<ServletDefinition> mockBinding = mock(Binding.class);
    when(mockBinding.getProvider()).thenReturn(bindingProvider);
    return mockBinding;
}
```
**mock `Injector` creation**：
```java
public final Injector createMockInjector(Binding<HttpServlet> binding, HttpServlet mockServlet, Binding<ServletDefinition> mockBinding) {
    final Key<ServletDefinition> servletDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));
    final Injector injector = mock(Injector.class);
    when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
    when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);
    when(injector.findBindingsByType(eq(servletDefsKey.getTypeLiteral())))
        .thenReturn(ImmutableList.of(mockBinding));
    return injector;
}
```

The code to create the mock before using these methods looks like this:

```java
final Injector injector = mock(Injector.class);//mock injector
final Binding<HttpServlet> binding = mock(Binding.class);//mock injector Binding<HttpServlet> 
//Other java code in testcase
when(binding.acceptScopingVisitor((BindingScopingVisitor) any())).thenReturn(true);
when(injector.getBinding(Key.get(HttpServlet.class))).thenReturn(binding);
when(injector.getInstance(HTTP_SERLVET_KEY)).thenReturn(mockServlet);

final Key<ServletDefinition> servetDefsKey = Key.get(TypeLiteral.get(ServletDefinition.class));

Binding<ServletDefinition> mockBinding = mock(Binding.class);//mock Binding<ServletDefinition>
when(injector.findBindingsByType(eq(servetDefsKey.getTypeLiteral())))
    .thenReturn(ImmutableList.<Binding<ServletDefinition>>of(mockBinding));
Provider<ServletDefinition> bindingProvider = Providers.of(servletDefinition);
when(mockBinding.getProvider()).thenReturn(bindingProvider);
```


Using these methods, the refactored code becomes much cleaner:

```java
final Binding<HttpServlet> binding = createMockBinding();
// Other code in the test case
Binding<ServletDefinition> mockBinding = createMockBinding(servletDefinition);
final Injector injector = createMockInjector(binding, mockServlet, mockBinding);
```

And for further improvement, we can overload `createMockInjector` for a more streamlined approach:

```java
public final Injector createMockInjector(ServletDefinition servletDefinition, HttpServlet mockServlet) {
    return createMockInjector(createMockBinding(), mockServlet, createMockBinding(servletDefinition));
}
```

This final refactored code is:

```java
// Other code in the test case
final Injector injector = createMockInjector(servletDefinition, mockServlet);
```

I’ve created a draft PR in my forked project where you can see the detailed changes [here](https://github.com/gzhao9/guice/pull/1/files).

The refactor reduced the test cases by 60 lines of code, and I believe these changes will improve code readability.